### PR TITLE
Remove year from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Jeff Madsen
+Copyright (c) Jeff Madsen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This has no additional value, so to prevent yearly updates (it's 2019 already, after all 😉) we'll just remove it.