### PR TITLE
Coverage of all route types 

### DIFF
--- a/src/app/Http/Middleware/CollectCodeCoverage.php
+++ b/src/app/Http/Middleware/CollectCodeCoverage.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Route;
 
 class CollectCodeCoverage {
 
@@ -25,13 +26,26 @@ class CollectCodeCoverage {
         $response = $next($request);
 
         if(app()->runningUnitTests()){
-
             // Record code coverage
             static::$routesTested[] = ['url'    => $request->getRequestUri(),
-                                       'name'   => optional(\Route::getCurrentRoute())->getName() ?? 'unknown',
+                                       'name'   => $this->getRouteName(Route::getCurrentRoute()) ?? 'unknown',
                                        'method' => $request->getMethod(),
             ];
         }
         return $response;
     }
+
+    protected function getRouteName($route){
+
+        if (!empty($route->getName())){
+            return $route->getName();
+        }
+
+        if ($route->getActionName() && $route->getActionName() !== 'Closure'){
+            return $route->getActionName();
+        }
+
+        return $route->getActionName() . ' /' . $route->uri();
+    }
+
 }

--- a/src/test/Feature/xCoverageTest.php
+++ b/src/test/Feature/xCoverageTest.php
@@ -16,27 +16,45 @@ use Tests\TestCase;
 class xCoverageTest extends TestCase {
 
     public function testCheckAllRoutesTested(){
+
         $routesTested = CollectCodeCoverage::$routesTested;
 
         $list = collect($routesTested)->groupBy("name");
         $missingRoutes = [];
+
         foreach(\Illuminate\Support\Facades\Route::getRoutes() as $route){
-            $routeName = $route->getName();
+
+            $routeName = $this->getMissingRouteName($route);
             $hits = $list->get($routeName);
 
             foreach($route->methods() as $method){
+
                 if($method === 'HEAD'){
                     continue;
                 }
                 else if($hits === null || $hits->where("method", '=', $method)->count() === 0){
                     $missingRoutes[] = $routeName . ' ' . $method;
                 }
+
             }
         }
 
         asort($missingRoutes);
 
         $this->assertSame(0, count($missingRoutes), "Missing feature tests for Routes:\n" . implode("\n", $missingRoutes));
+    }
+
+    public function getMissingRouteName(\Illuminate\Routing\Route $route)
+    {
+        if (!empty($route->getName())){
+            return $route->getName();
+        }
+
+        if ($route->getActionName() && $route->getActionName() !== 'Closure'){
+            return $route->getActionName();
+        }
+
+        return $route->getActionName() . ' /' . $route->uri();
     }
 
 }


### PR DESCRIPTION
Provides tracking for each of the following route types:
- named routes
- unnamed controller actions
- routes which use closures

I'm not aware of any other route type, but it should be able to cover anything you throw at it.

