### PR TITLE
Fix for $route sometimes being null in getRouteName()

### DIFF
--- a/publishable/app/Http/Middleware/CollectCodeCoverage.php
+++ b/publishable/app/Http/Middleware/CollectCodeCoverage.php
@@ -37,6 +37,10 @@ class CollectCodeCoverage {
 
     protected function getRouteName($route){
 
+        if (empty($route)) {
+            return '';
+        }
+        
         if (!empty($route->getName())){
             return $route->getName();
         }


### PR DESCRIPTION
Sometimes the route variable can be null, this will just ensure that calls on a null object are handled in a non-breaking way.

I also have another PR heading in shortly for some added functionality 😉