### PR TITLE
Fix for ignoring routes correctly

### DIFF
--- a/src/Helpers/RouteHelper.php
+++ b/src/Helpers/RouteHelper.php
@@ -56,7 +56,8 @@ class RouteHelper
         array_walk(
             $excludedRouteGroups,
             function ($excludeGroupName) use ($routeName, &$isExcluded) {
-                if ($isExcluded = Str::startsWith($routeName, $excludeGroupName.config('route_groups_seperator', '.'))) {
+                $isExcluded = $isExcluded ? $isExcluded : Str::startsWith($routeName, $excludeGroupName.config('route_groups_seperator', '.'));
+                if ($isExcluded) {
                     return;
                 }
             }


### PR DESCRIPTION
In Helpers/RouteHelper.php the isExcludedRoute function sets the scope
of the '$isExcluded' variable such that it doesn't get applied correctly
in the array_walk closure. This means that the route never gets excluded
correctly as expected. This can be confirmed by installing
barryvdh/laravel-debugbar and adding 'debugbar' to the 'exclude_route_groups'
config array. If this is done all debugbar routes are never excluded.